### PR TITLE
Update readme

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -115,6 +115,7 @@ GEM
     zeitwerk (2.6.0)
 
 PLATFORMS
+  arm64-darwin-21
   x86_64-darwin-21
 
 DEPENDENCIES

--- a/README.md
+++ b/README.md
@@ -8,7 +8,6 @@ The main website and frontpage for the Ruby Learning Center, built using Bridget
 - [Install](#install)
 - [Development](#development)
 - [Commands](#commands)
-- [Deployment](#deployment)
 - [Contributing](#contributing)
 
 ## Prerequisites
@@ -16,11 +15,8 @@ The main website and frontpage for the Ruby Learning Center, built using Bridget
 - [GCC](https://gcc.gnu.org/install/)
 - [Make](https://www.gnu.org/software/make/)
 - [Ruby](https://www.ruby-lang.org/en/downloads/)
-  - `>= 2.7`
 - [Bridgetown Gem](https://rubygems.org/gems/bridgetown)
-  - `gem install bridgetown -N`
 - [Node](https://nodejs.org)
-  - `>= 12`
 - [Yarn](https://yarnpkg.com)
 
 ## Install
@@ -51,13 +47,6 @@ bin/bridgetown console
 ```
 
 > Learn more: [Bridgetown CLI Documentation](https://www.bridgetownrb.com/docs/command-line-usage)
-
-## Deployment
-
-You can deploy Bridgetown sites on hosts like Render or Vercel as well as traditional web servers by simply building and copying the output folder to your HTML root.
-
-> Read the [Bridgetown Deployment Documentation](https://www.bridgetownrb.com/docs/deployment) for more information.
-
 ## Contributing
 
 If repo is on GitHub:


### PR DESCRIPTION
I tried to put my self in the shoes of someone who didn't know exactly what they were doing as they followed this readme. I think the following items could be improvements:

I removed the references to the versions of node and ruby. I noticed that it says it supports >= 2.7, but the ruby-versions file is 3.1.2 so instead of trying to keep this all in sync, we can just list out the dependencies and use the tooling to keep track of the real version dependencies. 

Also, since the install step has you running bundle I don't think there is value in showing the `gem install bridgetown -N` command to someone who might recognize that as something they could type into their terminal. I went ahead and removed it. 

I also removed the deployment step. I can imagine someone seeing this step between the "install" and "contribute" step and being confused about why that is there and wondering if there is something important about being able to deploy the website that is important before they contribute. Removing it makes that question disappear. 

Lastly, when I ran bundle install it added the `arm64-darwin-21` platform. I think this is okay to keep in here as well. 



