### PR TITLE
Mobile layout fix

### DIFF
--- a/frontend/styles/index.scss
+++ b/frontend/styles/index.scss
@@ -43,6 +43,12 @@ $backgroundShadow: #BD8D46;
 
 .flex {
   display: flex;
+  
+  @media (max-width: 500px) {
+    &.flex-column-mobile {
+      flex-direction: column;
+    }
+  }
 }
 
 .box-card {

--- a/frontend/styles/index.scss
+++ b/frontend/styles/index.scss
@@ -44,7 +44,7 @@ $backgroundShadow: #BD8D46;
 .flex {
   display: flex;
   
-  @media (max-width: 500px) {
+  @media (max-width: 700px) {
     &.flex-column-mobile {
       flex-direction: column;
     }

--- a/src/index.md
+++ b/src/index.md
@@ -29,7 +29,7 @@ Consider joining us on our <a href="<%= site.metadata.discord_link %>"  target="
 
   <br />
 
-  <div class="flex">
+  <div class="flex flex-column-mobile">
     <a href="https://rebuilding-rails.com/" target="_blank">
       <img
         src="<%= relative_url '/images/rebuilding_rails_cover.jpeg' %>"


### PR DESCRIPTION
On mobile the text for the class was hanging off the right of the screen, so this adds a media query and switches the flex direction to column for mobile.

(I didn't get a change to test this live, so hopefully the fix actually works!)